### PR TITLE
chore: workflows go version to be 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Build
       run: make build


### PR DESCRIPTION
# What?

- Update workflows go version to be 1.22

## Why?

- go version for application is 1.22 (from 1.21)
- Missed workflow go version