### PR TITLE
Feature/error channel handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ tidy:
 
 .PHONY: test
 test:
-	go test ./internal/...
+	go test -v ./internal/...
 
 .PHONY: bench-all
 bench-all: 

--- a/internal/domain/ip_mgmt/unique_ips.go
+++ b/internal/domain/ip_mgmt/unique_ips.go
@@ -1,5 +1,10 @@
 package ip_mgmt
 
-func UniqueIPs(ipCounts map[string]int) int {
-	return len(ipCounts)
+import "errors"
+
+func UniqueIPs(ipCounts map[string]int) (int, error) {
+	if len(ipCounts) == 0 {
+		return 0, errors.New("no IPs found")
+	}
+	return len(ipCounts), nil
 }

--- a/internal/domain/ip_mgmt/unique_ips_test.go
+++ b/internal/domain/ip_mgmt/unique_ips_test.go
@@ -1,15 +1,19 @@
 package ip_mgmt
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestUniqueIPs(t *testing.T) {
 	type args struct {
 		ipCounts map[string]int
 	}
 	tests := []struct {
-		name string
-		args args
-		want int
+		name    string
+		args    args
+		want    int
+		wantErr bool
 	}{
 		{
 			name: "Success: return the number of unique IPs",
@@ -22,12 +26,26 @@ func TestUniqueIPs(t *testing.T) {
 					"168.41.191.9": 1,
 				},
 			},
-			want: 5,
+			want:    5,
+			wantErr: false,
+		},
+		{
+			name: "Error: no IP's found",
+			args: args{
+				ipCounts: map[string]int{},
+			},
+			want:    0,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := UniqueIPs(tt.args.ipCounts); got != tt.want {
+			got, err := UniqueIPs(tt.args.ipCounts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UniqueIPs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("UniqueIPs() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/domain/log_mgmt/count_log_matches.go
+++ b/internal/domain/log_mgmt/count_log_matches.go
@@ -10,6 +10,9 @@ import (
  * Counts each unique IP address and URL(ignores queries)
  */
 func CountLogMatches(regex string, logChan <-chan string, urlCountChan chan<- map[string]int, ipCountChan chan<- map[string]int) {
+	defer close(urlCountChan)
+	defer close(ipCountChan)
+
 	// match the IP address and URL(ignore query). Used https://regex101.com/.
 	logRegex := regexp.MustCompile(regex)
 
@@ -34,7 +37,4 @@ func CountLogMatches(regex string, logChan <-chan string, urlCountChan chan<- ma
 
 	urlCountChan <- urlCount
 	ipCountChan <- ipCount
-
-	close(urlCountChan)
-	close(ipCountChan)
 }

--- a/internal/domain/log_mgmt/count_log_matches_test.go
+++ b/internal/domain/log_mgmt/count_log_matches_test.go
@@ -48,15 +48,15 @@ func TestCountLogMatches(t *testing.T) {
 			ipCountChan := make(chan map[string]int)
 			logChan := make(chan string, len(tt.args))
 
+			// execute
+			go CountLogMatches(cfg.Regex.MatchIPsURlsIgnoreQuery, logChan, urlCountChan, ipCountChan)
+
 			// create a loop
 			for _, log := range tt.args {
 				logChan <- log
 			}
 			// close channel
 			close(logChan)
-
-			// execute
-			go CountLogMatches(cfg.Regex.MatchIPsURlsIgnoreQuery, logChan, urlCountChan, ipCountChan)
 
 			// receive URL/IP counts
 			got := <-urlCountChan

--- a/internal/domain/log_mgmt/load_logs.go
+++ b/internal/domain/log_mgmt/load_logs.go
@@ -2,17 +2,20 @@ package log_mgmt
 
 import (
 	"bufio"
-	"log/slog"
 	"os"
 )
 
 /*
  *  Function reads logs one at a time and sends them through a log channel for concurrent processing
  */
-func LoadLogs(filePath string, logChan chan<- string) {
+func LoadLogs(filePath string, logChan chan<- string, errChan chan<- error) {
+	defer close(logChan)
+	defer close(errChan)
+
 	file, err := os.Open(filePath)
 	if err != nil {
-		slog.Error("file", "error", err)
+		errChan <- err
+		return
 	}
 	defer file.Close()
 
@@ -22,8 +25,7 @@ func LoadLogs(filePath string, logChan chan<- string) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		slog.Error("scanner", "error", err)
+		errChan <- err
+		return
 	}
-
-	close(logChan)
 }

--- a/internal/domain/log_mgmt/load_logs_test.go
+++ b/internal/domain/log_mgmt/load_logs_test.go
@@ -1,0 +1,70 @@
+package log_mgmt
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLoadLogs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        string
+		want        string
+		wantErr     error
+		wantErrBool bool
+	}{
+		{
+			name:        "Success: load one log",
+			args:        "./testdata/good.log",
+			want:        "177.71.128.21 - - [10/Jul/2018:22:22:08 +0200] \"GET /blog/2018/08/survey-your-opinion-matters/ HTTP/1.1\" 200 3574 \"-\" \"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1092.0 Safari/536.6\"",
+			wantErr:     nil,
+			wantErrBool: false,
+		},
+		{
+			name:        "Error: bad filepath",
+			args:        "./incorrect/filepath.log",
+			want:        "",
+			wantErr:     errors.New("open ./incorrect/filepath.log: no such file or directory"),
+			wantErrBool: true,
+		},
+		{
+			name:        "empty log",
+			args:        "./testdata/empty.log",
+			want:        "",
+			wantErr:     nil,
+			wantErrBool: false,
+		},
+	}
+	for _, tt := range tests {
+		// reference: https://www.timothyomargheim.com/posts/testing-channels-in-go/
+
+		t.Run(tt.name, func(t *testing.T) {
+			//setup for one log
+			logChan := make(chan string, 1)
+			errChan := make(chan error, 1)
+
+			// execute
+			go LoadLogs(tt.args, logChan, errChan)
+
+			// receive log/error
+			got := <-logChan
+			gotErr1 := <-errChan
+
+			// check to see if an error is received when no error is expected
+			if (gotErr1 != nil) != tt.wantErrBool {
+				t.Errorf("LoadLogs() error = %v, wantErr %v", gotErr1, tt.wantErr)
+				return
+			}
+			// check the error message
+			if tt.wantErrBool && gotErr1 != nil {
+				if gotErr1.Error() != tt.wantErr.Error() {
+					t.Errorf("LoadLogs() error message = %v, want %v", gotErr1, tt.wantErr)
+				}
+			}
+			// check no errors and the received outcome matches the expected outcome
+			if !tt.wantErrBool && got != tt.want {
+				t.Errorf("LoadLogs() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/log_mgmt/testdata/good.log
+++ b/internal/domain/log_mgmt/testdata/good.log
@@ -1,0 +1,1 @@
+177.71.128.21 - - [10/Jul/2018:22:22:08 +0200] "GET /blog/2018/08/survey-your-opinion-matters/ HTTP/1.1" 200 3574 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1092.0 Safari/536.6"


### PR DESCRIPTION
# What?

- add go channel for errors
- add error handling for UniqueIPs

## Why?

- populate a channel with errors if it occurs while opening up the the named file for reading or the first non-EOF error that was encountered by the [Scanner]

## How?

- create a new channel - specifically for errors
- in the main.go - receive errors from the error channel and check if there are any errors present
- if there are errors, stop the application (as the file has not been opened/logs have not been read)
- if UniqueIPs is 0 (i.e. none was found) - also stops the application (no need for it to continue)


## Testing?

- created LoadLogs Table driven tests. 
- Used https://www.timothyomargheim.com/posts/testing-channels-in-go/ as a reference to test channels in go

- LoadLogs tests:
<img width="673" alt="image" src="https://github.com/ESedrak/log-parser/assets/100348676/bb06d209-7ae9-427f-bb4e-9f1174c066fb">

- UniqueIPs tests
<img width="644" alt="image" src="https://github.com/ESedrak/log-parser/assets/100348676/2895f9aa-15c6-4cf9-94a8-8b6e4e4c294e">



## Anything Else?

- add testData for good log and and empty log file.
- Note: Only one log was used for testing
- When setting up the test - created a buffered channel was created with a capacity of 1.
```			
                        // setup for one log
			logChan := make(chan string, 1)
			errChan := make(chan error, 1)`
```
