### PR TITLE
feat: add optional CLI to specify requested number of results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-NUM_IPS ?= 3
-NUM_URLS ?= 3
-
 .PHONY: all
 all: tidy build test
 

--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ Check available commands (application uses a CLI):
 make run-help
 ```
 
-Run the application with default configuration (returns the top 3 URLs/IPs and number of unique IPs):
+Run the application with the default configuration (returns the top 3 URLs/IPs and number of unique IPs):
 
 ```sh
 make run-all
 ```
 
-Run the application with custom configurations (replace x with the number of IPs/URLs to return):
+Run the application with a custom configuration (replace x with the number of IPs/URLs to return):
 
 ```sh
 make run-all NUM_IPS=x NUM_URLS=x

--- a/cmd/logparser/main.go
+++ b/cmd/logparser/main.go
@@ -12,7 +12,7 @@ func init() {
 }
 
 func main() {
-	rootCmd := cli.NewCli()
+	rootCmd := cli.NewCLI()
 
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/cmd/logparser/main.go
+++ b/cmd/logparser/main.go
@@ -12,10 +12,7 @@ func init() {
 }
 
 func main() {
-	logPath := config.Values.Path.LogPath
-	regex := config.Values.Regex.MatchIPsURLsIgnoreQuery
-
-	rootCmd := cli.NewCli(logPath, regex)
+	rootCmd := cli.NewCli()
 
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,14 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCli(logPath string, regex string) *cobra.Command {
+func NewCli() *cobra.Command {
 
 	var logparser = &cobra.Command{
 		Use:   "logparser",
 		Short: "LogParser CLI application",
 		Long:  "Logparser CLI application\nUse this CLI for all your log parsing needs.",
 	}
-	logparser.AddCommand(logcli.NewLogCmd(logPath, regex))
+	logparser.AddCommand(logcli.NewLogCmd())
 
 	return logparser
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCli() *cobra.Command {
+func NewCLI() *cobra.Command {
 
 	var logparser = &cobra.Command{
 		Use:   "logparser",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,55 +1,53 @@
 package cli
 
-// func TestNewCli(t *testing.T) {
-// 	tests := []struct {
-// 		name          string
-// 		logPath       string
-// 		regex         string
-// 		wantUse       string
-// 		wantShort     string
-// 		wantLong      string
-// 		subCmdArgs    []string
-// 		wantSubCmdUse string
-// 	}{
-// 		{
-// 			name:          "Test NewCli",
-// 			logPath:       "logs/log_file.log",
-// 			regex:         "(\\d+\\.\\d+\\.\\d+\\.\\d+).+(?:GET|POST|PUT|DELETE|HEAD)\\s([^ ?]+)",
-// 			wantUse:       "logparser",
-// 			wantShort:     "LogParser CLI application",
-// 			wantLong:      "Logparser CLI application\nUse this CLI for all your log parsing needs.",
-// 			subCmdArgs:    []string{"log"},
-// 			wantSubCmdUse: "log -- ip unique - ip active $(IP_COUNT) - url top $(URL_COUNT)",
-// 		},
-// 	}
+import "testing"
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			rootCmd := NewCli(tt.logPath, tt.regex)
+func TestNewCLI(t *testing.T) {
+	tests := []struct {
+		name          string
+		wantUse       string
+		wantShort     string
+		wantLong      string
+		subCmdArgs    []string
+		wantSubCmdUse string
+	}{
+		{
+			name:          "Test NewCli",
+			wantUse:       "logparser",
+			wantShort:     "LogParser CLI application",
+			wantLong:      "Logparser CLI application\nUse this CLI for all your log parsing needs.",
+			subCmdArgs:    []string{"log"},
+			wantSubCmdUse: "log -- ip unique - ip active $(IP_COUNT) - url top $(URL_COUNT)",
+		},
+	}
 
-// 			// Verify the root command properties
-// 			if rootCmd.Use != tt.wantUse {
-// 				t.Errorf("Use: got %s, want %s", rootCmd.Use, tt.wantUse)
-// 			}
-// 			if rootCmd.Short != tt.wantShort {
-// 				t.Errorf("Short: got %s, want %s", rootCmd.Short, tt.wantShort)
-// 			}
-// 			if rootCmd.Long != tt.wantLong {
-// 				t.Errorf("Long: got %s, want %s", rootCmd.Long, tt.wantLong)
-// 			}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := NewCLI()
 
-// 			// Verify subcommand properties
-// 			subCmd, _, err := rootCmd.Find(tt.subCmdArgs)
-// 			if err != nil {
-// 				t.Errorf("Unexpected error finding subcommand: %v", err)
-// 			}
-// 			if subCmd == nil {
-// 				t.Error("Subcommand not found")
-// 			} else {
-// 				if subCmd.Use != tt.wantSubCmdUse {
-// 					t.Errorf("Subcommand Use: got %s, want %s", subCmd.Use, tt.wantSubCmdUse)
-// 				}
-// 			}
-// 		})
-// 	}
-// }
+			// Verify the root command properties
+			if rootCmd.Use != tt.wantUse {
+				t.Errorf("Use: got %s, want %s", rootCmd.Use, tt.wantUse)
+			}
+			if rootCmd.Short != tt.wantShort {
+				t.Errorf("Short: got %s, want %s", rootCmd.Short, tt.wantShort)
+			}
+			if rootCmd.Long != tt.wantLong {
+				t.Errorf("Long: got %s, want %s", rootCmd.Long, tt.wantLong)
+			}
+
+			// Verify subcommand properties
+			subCmd, _, err := rootCmd.Find(tt.subCmdArgs)
+			if err != nil {
+				t.Errorf("Unexpected error finding subcommand: %v", err)
+			}
+			if subCmd == nil {
+				t.Error("Subcommand not found")
+			} else {
+				if subCmd.Use != tt.wantSubCmdUse {
+					t.Errorf("Subcommand Use: got %s, want %s", subCmd.Use, tt.wantSubCmdUse)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,59 +1,55 @@
 package cli
 
-import (
-	"testing"
-)
+// func TestNewCli(t *testing.T) {
+// 	tests := []struct {
+// 		name          string
+// 		logPath       string
+// 		regex         string
+// 		wantUse       string
+// 		wantShort     string
+// 		wantLong      string
+// 		subCmdArgs    []string
+// 		wantSubCmdUse string
+// 	}{
+// 		{
+// 			name:          "Test NewCli",
+// 			logPath:       "logs/log_file.log",
+// 			regex:         "(\\d+\\.\\d+\\.\\d+\\.\\d+).+(?:GET|POST|PUT|DELETE|HEAD)\\s([^ ?]+)",
+// 			wantUse:       "logparser",
+// 			wantShort:     "LogParser CLI application",
+// 			wantLong:      "Logparser CLI application\nUse this CLI for all your log parsing needs.",
+// 			subCmdArgs:    []string{"log"},
+// 			wantSubCmdUse: "log -- ip unique - ip active $(IP_COUNT) - url top $(URL_COUNT)",
+// 		},
+// 	}
 
-func TestNewCli(t *testing.T) {
-	tests := []struct {
-		name          string
-		logPath       string
-		regex         string
-		wantUse       string
-		wantShort     string
-		wantLong      string
-		subCmdArgs    []string
-		wantSubCmdUse string
-	}{
-		{
-			name:          "Test NewCli",
-			logPath:       "logs/log_file.log",
-			regex:         "(\\d+\\.\\d+\\.\\d+\\.\\d+).+(?:GET|POST|PUT|DELETE|HEAD)\\s([^ ?]+)",
-			wantUse:       "logparser",
-			wantShort:     "LogParser CLI application",
-			wantLong:      "Logparser CLI application\nUse this CLI for all your log parsing needs.",
-			subCmdArgs:    []string{"log"},
-			wantSubCmdUse: "log -- ip unique - ip active $(IP_COUNT) - url top $(URL_COUNT)",
-		},
-	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			rootCmd := NewCli(tt.logPath, tt.regex)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rootCmd := NewCli(tt.logPath, tt.regex)
+// 			// Verify the root command properties
+// 			if rootCmd.Use != tt.wantUse {
+// 				t.Errorf("Use: got %s, want %s", rootCmd.Use, tt.wantUse)
+// 			}
+// 			if rootCmd.Short != tt.wantShort {
+// 				t.Errorf("Short: got %s, want %s", rootCmd.Short, tt.wantShort)
+// 			}
+// 			if rootCmd.Long != tt.wantLong {
+// 				t.Errorf("Long: got %s, want %s", rootCmd.Long, tt.wantLong)
+// 			}
 
-			// Verify the root command properties
-			if rootCmd.Use != tt.wantUse {
-				t.Errorf("Use: got %s, want %s", rootCmd.Use, tt.wantUse)
-			}
-			if rootCmd.Short != tt.wantShort {
-				t.Errorf("Short: got %s, want %s", rootCmd.Short, tt.wantShort)
-			}
-			if rootCmd.Long != tt.wantLong {
-				t.Errorf("Long: got %s, want %s", rootCmd.Long, tt.wantLong)
-			}
-
-			// Verify subcommand properties
-			subCmd, _, err := rootCmd.Find(tt.subCmdArgs)
-			if err != nil {
-				t.Errorf("Unexpected error finding subcommand: %v", err)
-			}
-			if subCmd == nil {
-				t.Error("Subcommand not found")
-			} else {
-				if subCmd.Use != tt.wantSubCmdUse {
-					t.Errorf("Subcommand Use: got %s, want %s", subCmd.Use, tt.wantSubCmdUse)
-				}
-			}
-		})
-	}
-}
+// 			// Verify subcommand properties
+// 			subCmd, _, err := rootCmd.Find(tt.subCmdArgs)
+// 			if err != nil {
+// 				t.Errorf("Unexpected error finding subcommand: %v", err)
+// 			}
+// 			if subCmd == nil {
+// 				t.Error("Subcommand not found")
+// 			} else {
+// 				if subCmd.Use != tt.wantSubCmdUse {
+// 					t.Errorf("Subcommand Use: got %s, want %s", subCmd.Use, tt.wantSubCmdUse)
+// 				}
+// 			}
+// 		})
+// 	}
+// }

--- a/internal/cli/ipcli/findactiveip.go
+++ b/internal/cli/ipcli/findactiveip.go
@@ -8,26 +8,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newFindMostActiveIP() *cobra.Command {
+func newFindMostActiveIP(ipCounts map[string]int, requestedNumIP int) *cobra.Command {
 	ipFindActiveCmd := &cobra.Command{
 		Use:   "active",
-		Short: "Find the most active IP",
-		Long:  "Find the most active IP. \nRequested number of results is a required argument.",
-		Args:  cobra.ExactArgs(1),
+		Short: "Return the most active IPs",
+		Long:  "Return the most active IPs. \nSpecify the requested number of results to return. Otherwise it will default to the configs requestedNum for IPs",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			requestedNum, err := strconv.Atoi(args[0])
-			if err != nil {
-				slog.Error("Requested number of IPs to return must be an integer", "err", err)
-				return
+			var requestedNum int
+			var err error
+
+			if len(args) == 0 {
+				requestedNum = requestedNumIP
+			} else {
+				requestedNum, err = strconv.Atoi(args[0])
+				if err != nil {
+					slog.Error("Requested number of IPs to return must be an integer", "err", err)
+					return
+				}
 			}
-			findMostActiveIP(requestedNum)
+			findMostActiveIP(ipCounts, requestedNum)
 		},
 	}
 
 	return ipFindActiveCmd
 }
 
-func findMostActiveIP(requestedNum int) {
+func findMostActiveIP(ipCounts map[string]int, requestedNum int) {
 
 	result, err := ip_mgmt.MostActiveIP(ipCounts, requestedNum)
 	cobra.CheckErr(err)

--- a/internal/cli/ipcli/finduniqueip.go
+++ b/internal/cli/ipcli/finduniqueip.go
@@ -7,21 +7,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newFindUniqueIP() *cobra.Command {
+func newFindUniqueIP(ipCounts map[string]int) *cobra.Command {
 	ipFindActiveCmd := &cobra.Command{
 		Use:   "unique",
-		Short: "Find the number of unique IPs",
-		Long:  "Find the number of unique IPs within a log file",
+		Short: "Return the number of unique IPs",
+		Long:  "Return the number of unique IPs within a log file",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			findUniquIP()
+			findUniquIP(ipCounts)
 		},
 	}
 
 	return ipFindActiveCmd
 }
 
-func findUniquIP() {
+func findUniquIP(ipCounts map[string]int) {
 
 	result, err := ip_mgmt.UniqueIPs(ipCounts)
 	cobra.CheckErr(err)

--- a/internal/cli/ipcli/ipcli.go
+++ b/internal/cli/ipcli/ipcli.go
@@ -2,17 +2,14 @@ package ipcli
 
 import "github.com/spf13/cobra"
 
-var ipCounts map[string]int
-
-func NewIPCmd(ipCount map[string]int) *cobra.Command {
-	ipCounts = ipCount
+func NewIPCmd(ipCounts map[string]int, requestedNumIP int) *cobra.Command {
 	var ipCmd = &cobra.Command{
 		Use:   "ip",
 		Short: "IP related commands",
 		Long:  "IP related commands",
 	}
 
-	ipCmd.AddCommand(newFindMostActiveIP(), newFindUniqueIP())
+	ipCmd.AddCommand(newFindMostActiveIP(ipCounts, requestedNumIP), newFindUniqueIP(ipCounts))
 
 	return ipCmd
 }

--- a/internal/cli/urlcli/findtopurl.go
+++ b/internal/cli/urlcli/findtopurl.go
@@ -8,26 +8,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newFindTopRequestedURLs() *cobra.Command {
+func newFindTopRequestedURLs(urlCounts map[string]int, requestedNumURL int) *cobra.Command {
 	urlFindTopRequestedCmd := &cobra.Command{
 		Use:   "top",
-		Short: "Find the top requested URLs",
-		Long:  "Find the top requested URLs. \nRequested number of results is a required argument.",
-		Args:  cobra.ExactArgs(1),
+		Short: "Return the top requested URLs",
+		Long:  "Return the top requested URLs. \nSpecify the requested number of results to return. Otherwise it will default to the configs requestedNum for URLs",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			requestedNum, err := strconv.Atoi(args[0])
-			if err != nil {
-				slog.Error("Requested number of URLs to return must be an integer", "err", err)
-				return
+			var requestedNum int
+			var err error
+
+			if len(args) == 0 {
+				requestedNum = requestedNumURL
+			} else {
+				requestedNum, err = strconv.Atoi(args[0])
+				if err != nil {
+					slog.Error("Requested number of URLs to return must be an integer", "err", err)
+					return
+				}
 			}
-			findTopRequestedURLs(requestedNum)
+			findTopRequestedURLs(urlCounts, requestedNum)
 		},
 	}
 
 	return urlFindTopRequestedCmd
 }
 
-func findTopRequestedURLs(requestedNum int) {
+func findTopRequestedURLs(urlCounts map[string]int, requestedNum int) {
 
 	result, err := url_mgmt.TopRequestedURLs(urlCounts, requestedNum)
 	cobra.CheckErr(err)

--- a/internal/cli/urlcli/urlcli.go
+++ b/internal/cli/urlcli/urlcli.go
@@ -2,17 +2,14 @@ package urlcli
 
 import "github.com/spf13/cobra"
 
-var urlCounts map[string]int
-
-func NewURLCmd(urlCount map[string]int) *cobra.Command {
-	urlCounts = urlCount
+func NewURLCmd(urlCounts map[string]int, requestedNumURL int) *cobra.Command {
 	var urlCmd = &cobra.Command{
 		Use:   "url",
 		Short: "URL related commands",
 		Long:  "URL related commands",
 	}
 
-	urlCmd.AddCommand(newFindTopRequestedURLs())
+	urlCmd.AddCommand(newFindTopRequestedURLs(urlCounts, requestedNumURL))
 
 	return urlCmd
 }


### PR DESCRIPTION
# What?

- Add the ability of the requested number of results to be optional (will default to config, if no argument is given)

## Why?

- Uses the config file as a default to specify how many results are returned for both IPs/URLs

## How?

- Originally cobra args was an exact 1 (meaning it was required to have specified a number to return)
- Now cobra uses cobra.MaximumNArgs(1) to indicate the number of args could be either 0 or 1
- Then checks to see if a an argument has been given (the number of results to return), otherwise it uses the configs default value (currently set to 3)

## Testing?

- make test: success



